### PR TITLE
Create a fake server to use with BungeeTabListPlus

### DIFF
--- a/src/main/java/com/cnaude/purpleirc/Hooks/BungeeTabListPlusHook.java
+++ b/src/main/java/com/cnaude/purpleirc/Hooks/BungeeTabListPlusHook.java
@@ -3,6 +3,7 @@ package com.cnaude.purpleirc.Hooks;
 import codecrafter47.bungeetablistplus.api.bungee.BungeeTabListPlusAPI;
 import codecrafter47.bungeetablistplus.api.bungee.FakePlayerManager;
 import codecrafter47.bungeetablistplus.api.bungee.tablist.FakePlayer;
+import com.cnaude.purpleirc.IRCServerInfo;
 import com.cnaude.purpleirc.PurpleBot;
 import com.cnaude.purpleirc.PurpleIRC;
 import java.util.Collection;
@@ -60,7 +61,7 @@ public class BungeeTabListPlusHook {
             }
         }
         plugin.logDebug("[addToTabList] [fp]: " + displayName);
-        ServerInfo server = (ServerInfo) plugin.getProxy().getServers().values().toArray()[0];
+        ServerInfo server = new IRCServerInfo(plugin.ircMinecraftServerName);
         FakePlayer fakePlayer = fakePlayerManager.createFakePlayer(displayName, server);
         fakePlayer.setPing(47);
         if (!plugin.customTabIcon.isEmpty()) {

--- a/src/main/java/com/cnaude/purpleirc/IRCServerInfo.java
+++ b/src/main/java/com/cnaude/purpleirc/IRCServerInfo.java
@@ -1,0 +1,61 @@
+package com.cnaude.purpleirc;
+
+import net.md_5.bungee.api.Callback;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.ServerPing;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+
+/**
+ * Created by krachynski on 2016-12-14.
+ */
+public class IRCServerInfo implements ServerInfo {
+    private final String ircMinecraftServerName;
+
+    public IRCServerInfo(String ircMinecraftServerName) {
+        this.ircMinecraftServerName = ircMinecraftServerName;
+    }
+
+    @Override
+    public String getName() {
+        return ircMinecraftServerName;
+    }
+
+    @Override
+    public InetSocketAddress getAddress() {
+        return null;
+    }
+
+    @Override
+    public Collection<ProxiedPlayer> getPlayers() {
+        return null;
+    }
+
+    @Override
+    public String getMotd() {
+        return null;
+    }
+
+    @Override
+    public boolean canAccess(CommandSender commandSender) {
+        return false;
+    }
+
+    @Override
+    public void sendData(String s, byte[] bytes) {
+
+    }
+
+    @Override
+    public boolean sendData(String s, byte[] bytes, boolean b) {
+        return false;
+    }
+
+    @Override
+    public void ping(Callback<ServerPing> callback) {
+
+    }
+}

--- a/src/main/java/com/cnaude/purpleirc/PurpleIRC.java
+++ b/src/main/java/com/cnaude/purpleirc/PurpleIRC.java
@@ -114,6 +114,7 @@ public class PurpleIRC extends Plugin {
     private final CaseInsensitiveMap<CaseInsensitiveMap<String>> mvActionMessages;
     private final CaseInsensitiveMap<CaseInsensitiveMap<String>> ircMvChannelMessages;
     private final CaseInsensitiveMap<CaseInsensitiveMap<String>> ircMvActionMessages;
+    public String ircMinecraftServerName;
 
     public PurpleIRC() {
         this.sortedCommands = new ArrayList<>();
@@ -371,6 +372,7 @@ public class PurpleIRC extends Plugin {
         customTabList = mainConfig.getBoolean("custom-tab-list", false);
         customTabIcon = mainConfig.getString("custom-tab-icon", "MHF_ArrowRight");
         logDebug("custom-tab-prefix: " + customTabPrefix);
+        ircMinecraftServerName = mainConfig.getString("irc-minecraft-server-name", "Webchat");
     }
 
     private void loadBots() {


### PR DESCRIPTION
Create a fake server to use with BungeeTabListPlus

On our server, it was slightly confusing to see all the IRC users apparently
connected to our survival server. So I added a ServerInfo class that allows
us to give a custom server name for these users. Server is named
"Webchat" by default and can be controlled by config.