### PR TITLE
Use %DISPLAYNAME% instead of player prefix and suffix in multichat -> IRC messages

### DIFF
--- a/src/main/java/com/cnaude/purpleirc/GameListeners/MultiChatListener.java
+++ b/src/main/java/com/cnaude/purpleirc/GameListeners/MultiChatListener.java
@@ -29,10 +29,7 @@ public class MultiChatListener implements Listener {
      */
     @EventHandler
     public void onPostGlobalChatEvent(PostGlobalChatEvent event) {
-        plugin.ircBots.values().forEach((ircBot) -> {
-            // player, message
-            ircBot.multiChat(event.getSender(), event.getSenderPrefix(), event.getSenderSuffix(), event.getMessage());
-        });
+        plugin.ircBots.values().forEach((ircBot) -> ircBot.multiChatGlobal(event.getSender(), event.getMessage()));
 
     }
     
@@ -42,9 +39,7 @@ public class MultiChatListener implements Listener {
      */
     @EventHandler
     public void onPostBroadcastEvent(PostBroadcastEvent event) {
-        plugin.ircBots.values().forEach((ircBot) -> {
-            ircBot.multiChat(event.getMessage());
-        });
+        plugin.ircBots.values().forEach((ircBot) -> ircBot.multiChatBroadcast(event.getMessage()));
 
     }
 
@@ -54,9 +49,7 @@ public class MultiChatListener implements Listener {
      */
     @EventHandler
     public void onPostStaffChatEvent(PostStaffChatEvent event) {
-        plugin.ircBots.values().forEach((ircBot) -> {
-            ircBot.multiChat(event.getSender(), event.getSenderPrefix(), event.getSenderSuffix(), event.getMessage());
-        });
+        plugin.ircBots.values().forEach((ircBot) -> ircBot.multiChatStaff(event.getSender(), event.getMessage()));
 
     }
 }

--- a/src/main/java/com/cnaude/purpleirc/PurpleBot.java
+++ b/src/main/java/com/cnaude/purpleirc/PurpleBot.java
@@ -937,7 +937,7 @@ public final class PurpleBot {
      * @param player
      * @param message
      */
-    public void multiChat(ProxiedPlayer player, String prefix, String suffix, String message) {
+    public void multiChatGlobal(ProxiedPlayer player, String message) {
         if (!this.isConnected()) {
             return;
         }
@@ -949,7 +949,7 @@ public final class PurpleBot {
             if (isMessageEnabled(channelName, tmpl)) {
                 plugin.logDebug("[" + tmpl + "] => " + channelName + " => " + message);
                 asyncIRCMessage(channelName, plugin.tokenizer
-                        .gameChatToIRCTokenizer(player, prefix, suffix, plugin.getMsgTemplate(botNick, tmpl), message));
+                        .gameChatToIRCTokenizer(player, plugin.getMsgTemplate(botNick, tmpl), message));
             } else {
                 plugin.logDebug("Message type " + tmpl + " is not enabled. Ignoring message.");
             }
@@ -962,7 +962,7 @@ public final class PurpleBot {
      * @param sender
      * @param message
      */
-    public void multiChat(CommandSender sender, String message) {
+    public void multiChatStaff(CommandSender sender, String message) {
         if (!this.isConnected()) {
             return;
         }
@@ -978,36 +978,13 @@ public final class PurpleBot {
             }
         }
     }
-    
-        /**
-     * Called from multichat staff chat listener
-     *
-     * @param sender
-     * @param message
-     */
-    public void multiChat(CommandSender sender, String prefix, String suffix, String message) {
-        if (!this.isConnected()) {
-            return;
-        }
-        String tmpl = TemplateName.MC_STAFF_CHAT;
-        for (String channelName : botChannels) {
-            if (isMessageEnabled(channelName, tmpl)) {
-                plugin.logDebug("[" + tmpl + "] => "
-                        + channelName + " => " + message);
-                asyncIRCMessage(channelName, plugin.tokenizer
-                        .gameChatToIRCTokenizer(sender, prefix, suffix, plugin.getMsgTemplate(botNick, tmpl), message));
-            } else {
-                plugin.logDebug("Message type " + tmpl + " is not enabled. Ignoring message.");
-            }
-        }
-    }
 
     /**
      * Called from multichat broadcast chat listener
      *
      * @param message
      */
-    public void multiChat(String message) {
+    public void multiChatBroadcast(String message) {
         if (!this.isConnected()) {
             return;
         }


### PR DESCRIPTION
Currently player prefix and suffix of multichat messages are not parsed correctly for colours. 
This change brings it more inline with how game chats are handled and uses %DISPLAYNAME% to display the prefixes and suffixes instead of directly accessing them.

- Minor change
- Only affects Multichat -> IRC messages
- Tested on test server with latest Multichat