### PR TITLE
Players with no perms can still run commands. (Issue #18)

### DIFF
--- a/src/main/java/com/cnaude/purpleirc/CommandHandlers.java
+++ b/src/main/java/com/cnaude/purpleirc/CommandHandlers.java
@@ -105,8 +105,9 @@ public class CommandHandlers extends Command {
             if (commands.containsKey(subCmd)) {
                 if (!sender.hasPermission("irc." + subCmd)) {
                     sender.sendMessage(new TextComponent(plugin.noPermission));
+                } else {
+                    commands.get(subCmd).dispatch(sender, args);
                 }
-                commands.get(subCmd).dispatch(sender, args);
                 return;
             }
         }


### PR DESCRIPTION
This patch fixes #18: If a player does not have permission to run a command, they will be shown an error message, but the command will still be executed. 